### PR TITLE
Port XmlExtractor to Scala 2.13.10

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         scala:
-          - 2.13.1
+          - 2.13.10
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Scala 2.13.9 and 2.13.10 slightly changed the AST for XML element without any attribute. This commit changes the extract accordingly.